### PR TITLE
業者の違う商品がカートに混在しないように

### DIFF
--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -12,13 +12,14 @@ class Cart < ApplicationRecord
 
     begin
       guest_cart.transaction do
+        current_vendor_id = cart_items.first&.vendor_id
         guest_cart.cart_items.each do |item|
-          existing_item = cart_items.find_by(product_id: item.product.id)
+          if current_vendor_id && current_vendor_id != item.vendor_id
+            raise StandardError, '違う販売元の商品をカートに入れることはできません。'
+          end
 
+          existing_item = cart_items.find_by(product_id: item.product.id)
           if existing_item
-            if existing_item.vendor_id != item.vendor_id
-              raise StandardError, '違う販売元の商品をカートに入れることはできません。'
-            end
             existing_item.update(quantity: existing_item.quantity + item.quantity)
           else
             cart_items.create(product_id: item.product.id, quantity: item.quantity, vendor_id: item.vendor.id)

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -12,9 +12,9 @@ class Cart < ApplicationRecord
 
     begin
       guest_cart.transaction do
-        current_vendor_id = cart_items.first&.vendor_id
+        vendor_id = cart_items.first&.vendor_id
         guest_cart.cart_items.each do |item|
-          if current_vendor_id && current_vendor_id != item.vendor_id
+          if vendor_id && vendor_id != item.vendor_id
             raise StandardError, '違う販売元の商品をカートに入れることはできません。'
           end
 

--- a/app/views/carts/show.html.haml
+++ b/app/views/carts/show.html.haml
@@ -59,6 +59,7 @@
               = continue_shopping
       -else
         .text-center.my-4
+          = link_to 'ログインして購入する', new_purchase_path, class: 'bg-indigo-600 text-white py-2 px-4 rounded hover:bg-indigo-700'
           = continue_shopping
   - else
     %p.text-center カートには何も入っていません。

--- a/spec/system/products_spec.rb
+++ b/spec/system/products_spec.rb
@@ -384,6 +384,7 @@ RSpec.describe 'Products', type: :system do
           expect(page).to have_content '1,000円'
 
           user_login(user)
+          expect(page).to have_content 'ログインしました。'
           click_on 'カート'
 
           expect(page).to have_css 'h1', text: 'カート'
@@ -408,6 +409,7 @@ RSpec.describe 'Products', type: :system do
           expect(page).to have_content '1,000円'
 
           user_login(user)
+          expect(page).to have_content 'ログインしました。'
           click_on 'カート'
 
           expect(page).to have_css 'h1', text: 'カート'

--- a/spec/system/products_spec.rb
+++ b/spec/system/products_spec.rb
@@ -208,6 +208,7 @@ RSpec.describe 'Products', type: :system do
         expect(page).to have_css 'h1', text: 'カート'
         expect(page).to have_css 'img.product-image'
         expect(page).to have_content 'ピーマン'
+        expect(page).to have_content 'アリスファーム'
         expect(page).to have_content '1,000円'
       end
     end
@@ -228,6 +229,7 @@ RSpec.describe 'Products', type: :system do
           expect(page).to have_css 'h1', text: 'カート'
           expect(page).to have_css 'img.product-image'
           expect(page).to have_content 'ピーマン'
+          expect(page).to have_content 'アリスファーム'
           expect(page).to have_content '1,000円'
           expect(page).to have_content '2'
           expect(page).to have_content '2,000円'
@@ -329,6 +331,7 @@ RSpec.describe 'Products', type: :system do
 
         expect(page).to have_css 'h1', text: 'カート'
         expect(page).to have_content 'ピーマン'
+        expect(page).to have_content 'アリスファーム'
         expect(page).to have_content 1
         expect(page).to have_content '1,000円'
         click_on 'ログアウト'
@@ -345,24 +348,29 @@ RSpec.describe 'Products', type: :system do
 
           expect(page).to have_css 'h1', text: 'カート'
           expect(page).to have_content 'ピーマン'
+          expect(page).to have_content 'アリスファーム'
           expect(page).to have_content 1
           expect(page).to have_content '1,000円'
 
           user_login(user)
+          expect(page).to have_content 'ログインしました。'
           click_on 'カート'
 
           expect(page).to have_css 'h1', text: 'カート'
           expect(page).to have_content 'ピーマン'
+          expect(page).to have_content 'アリスファーム'
           expect(page).to have_content 2
           expect(page).to have_content '2,000円'
         end
       end
 
       context 'カートの商品の業者と異なる場合' do
-        let(:unselectable_vendor) { create(:vendor, name: 'ボブ食堂') }
-        let!(:unselectable_vendor_stock) { create(:stock, product:, vendor: unselectable_vendor) }
+        let(:different_vendor) { create(:vendor, name: 'ボブ食堂') }
+        let!(:product1) { create(:product, name: 'にんじん', sort_position: 2) }
+        let!(:different_vendor_stock) { create(:stock, product:, vendor: different_vendor) }
+        let!(:different_vendor_stock1) { create(:stock, product: product1, vendor: different_vendor) }
 
-        it '商品は引き継がれない' do
+        it '同じ商品は引き継がれない' do
           visit products_path
           click_on 'ピーマン'
 
@@ -371,6 +379,7 @@ RSpec.describe 'Products', type: :system do
 
           expect(page).to have_css 'h1', text: 'カート'
           expect(page).to have_content 'ピーマン'
+          expect(page).to have_content 'ボブ食堂'
           expect(page).to have_content 1
           expect(page).to have_content '1,000円'
 
@@ -379,8 +388,34 @@ RSpec.describe 'Products', type: :system do
 
           expect(page).to have_css 'h1', text: 'カート'
           expect(page).to have_content 'ピーマン'
+          expect(page).to have_content 'アリスファーム'
           expect(page).to have_content 1
           expect(page).to have_content '1,000円'
+          expect(page).to_not have_content 'ボブ食堂'
+        end
+
+        it '別の商品も引き継がれない' do
+          visit products_path
+          click_on 'にんじん'
+
+          find('#cart_item_vendor_id').select('ボブ食堂')
+          click_on 'カートに追加'
+
+          expect(page).to have_css 'h1', text: 'カート'
+          expect(page).to have_content 'にんじん'
+          expect(page).to have_content 'ボブ食堂'
+          expect(page).to have_content 1
+          expect(page).to have_content '1,000円'
+
+          user_login(user)
+          click_on 'カート'
+
+          expect(page).to have_css 'h1', text: 'カート'
+          expect(page).to have_content 'ピーマン'
+          expect(page).to have_content 'アリスファーム'
+          expect(page).to have_content 1
+          expect(page).to have_content '1,000円'
+          expect(page).to_not have_content 'ボブ食堂'
         end
       end
     end


### PR DESCRIPTION
## 修正内容
- ログイン時にカートに入れていない商品をセッションでカートに入れた場合、
ログイン後、業者が違くても商品がカートに追加されてしまっていたので追加されないよう修正